### PR TITLE
Fix timezone handling in date input to use UTC

### DIFF
--- a/internal/handlers/expense_shared.go
+++ b/internal/handlers/expense_shared.go
@@ -40,19 +40,18 @@ func DateRangeOptions() []struct {
 }
 
 func computeDateRange(key string) (dateRange, bool) {
-	now := time.Now()
+	now := time.Now().UTC()
 	year, month, _ := now.Date()
-	loc := now.Location()
 
 	switch key {
 	case "this_month":
-		start := time.Date(year, month, 1, 0, 0, 0, 0, loc)
+		start := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
 		end := start.AddDate(0, 1, 0)
 
 		return dateRange{start.Unix(), end.Unix()}, true
 	case "last_month":
-		start := time.Date(year, month-1, 1, 0, 0, 0, 0, loc)
-		end := time.Date(year, month, 1, 0, 0, 0, 0, loc)
+		start := time.Date(year, month-1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
 
 		return dateRange{start.Unix(), end.Unix()}, true
 	case "this_week":
@@ -61,18 +60,18 @@ func computeDateRange(key string) (dateRange, bool) {
 			weekday = 7
 		}
 		monday := now.AddDate(0, 0, -int(weekday-time.Monday))
-		start := time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, loc)
+		start := time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, time.UTC)
 		end := start.AddDate(0, 0, 7)
 
 		return dateRange{start.Unix(), end.Unix()}, true
 	case "six_months":
-		start := time.Date(year, month-6, 1, 0, 0, 0, 0, loc)
-		end := time.Date(year, month, 1, 0, 0, 0, 0, loc).AddDate(0, 1, 0)
+		start := time.Date(year, month-6, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 1, 0)
 
 		return dateRange{start.Unix(), end.Unix()}, true
 	case "this_year":
-		start := time.Date(year, 1, 1, 0, 0, 0, 0, loc)
-		end := time.Date(year+1, 1, 1, 0, 0, 0, 0, loc)
+		start := time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)
+		end := time.Date(year+1, 1, 1, 0, 0, 0, 0, time.UTC)
 
 		return dateRange{start.Unix(), end.Unix()}, true
 	default:

--- a/internal/prog/utility.go
+++ b/internal/prog/utility.go
@@ -77,7 +77,7 @@ func parseError(value any, fieldName string, err error) error {
 }
 
 func UnixToStringDate(date int64, format string) string {
-	normalDate := time.Unix(date, 0)
+	normalDate := time.Unix(date, 0).UTC()
 
 	return FormatTime(normalDate, format)
 }

--- a/internal/serve/template_func_test.go
+++ b/internal/serve/template_func_test.go
@@ -133,7 +133,7 @@ func TestTimeStamp(t *testing.T) {
 		}},
 		{"epoch timestamp", func(t *testing.T) {
 			result := renderTemplate(t, tmpl, int64(0))
-			expected := time.Unix(0, 0).Format(time.DateOnly)
+			expected := time.Unix(0, 0).UTC().Format(time.DateOnly)
 			require.Equal(t, expected, result)
 		}},
 	}

--- a/web/static/js/controllers/dateController.ts
+++ b/web/static/js/controllers/dateController.ts
@@ -17,18 +17,13 @@ export default class extends Controller {
       return;
     }
 
-    const parsed = new Date(localDate);
-    if (Number.isNaN(parsed.getTime())) {
-      this.valueTarget.value = "";
-      return;
-    }
-
-    this.valueTarget.value = toRFC3339WithOffset(parsed);
+    // Send as UTC midnight to preserve the calendar date regardless of timezone
+    this.valueTarget.value = localDate + "T00:00:00Z";
   }
 
   private hydrateLocalDate() {
     const setCurrentLocalDate = () => {
-      this.localTarget.value = toLocalDateTimeInput(new Date());
+      this.localTarget.value = toLocalDate(new Date());
     };
 
     if (this.localTarget.value) {
@@ -50,7 +45,7 @@ export default class extends Controller {
 
       const date = new Date(unix * 1000);
       if (!Number.isNaN(date.getTime())) {
-        this.localTarget.value = toLocalDateTimeInput(date);
+        this.localTarget.value = toUTCDate(date);
 
         return;
       }
@@ -62,7 +57,7 @@ export default class extends Controller {
 
     const parsed = new Date(rawValue);
     if (!Number.isNaN(parsed.getTime())) {
-      this.localTarget.value = toLocalDateTimeInput(parsed);
+      this.localTarget.value = toUTCDate(parsed);
 
       return;
     }
@@ -71,23 +66,20 @@ export default class extends Controller {
   }
 }
 
-function toRFC3339WithOffset(date: Date): string {
-  const offset = -date.getTimezoneOffset();
-  const sign = offset >= 0 ? "+" : "-";
-  const absOffset = Math.abs(offset);
-  const hours = String(Math.floor(absOffset / 60)).padStart(2, "0");
-  const mins = String(absOffset % 60).padStart(2, "0");
-
-  return date.toISOString().slice(0, 19) + `${sign}${hours}:${mins}`;
-}
-
-function toLocalDateTimeInput(date: Date): string {
+// Returns the local calendar date as YYYY-MM-DD (used for defaulting to today)
+function toLocalDate(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
-  const hours = String(date.getHours()).padStart(2, "0");
-  const minutes = String(date.getMinutes()).padStart(2, "0");
-  const seconds = String(date.getSeconds()).padStart(2, "0");
 
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+  return `${year}-${month}-${day}`;
+}
+
+// Returns the UTC calendar date as YYYY-MM-DD (used when hydrating a stored UTC timestamp)
+function toUTCDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
 }

--- a/web/views/expenses/_form.html
+++ b/web/views/expenses/_form.html
@@ -36,10 +36,9 @@
     value="{{ .tagsInput }}"
   />
   <input
-    type="datetime-local"
+    type="date"
     placeholder="Date"
     data-date-target="local"
-    step="1"
   />
   <input
     type="hidden"


### PR DESCRIPTION
## Summary
This PR fixes timezone-related bugs in date handling by standardizing on UTC for stored dates and using local calendar dates for user input. The changes ensure that calendar dates are preserved correctly regardless of the user's timezone.

## Key Changes
- **Date input type**: Changed from `datetime-local` to `date` in the expense form, simplifying the UI to only capture the calendar date without time
- **Date serialization**: Modified to send dates as UTC midnight (`YYYY-MM-DDTHH:00:00Z`) to preserve the calendar date regardless of timezone
- **Removed timezone offset logic**: Eliminated the `toRFC3339WithOffset()` function that was attempting to preserve timezone information, which was causing inconsistencies
- **Utility functions refactored**:
  - `toLocalDate()`: Returns local calendar date as `YYYY-MM-DD` (used for defaulting to today)
  - `toUTCDate()`: Returns UTC calendar date as `YYYY-MM-DD` (used when hydrating stored UTC timestamps)
- **Backend UTC conversion**: Updated `UnixToStringDate()` in Go to explicitly convert to UTC before formatting, ensuring consistent date representation across timezones
- **Test updates**: Updated test expectations to use UTC conversion for timestamp formatting

## Implementation Details
- The date input now only captures the calendar date (no time component), eliminating timezone ambiguity at the UI level
- Dates are stored and transmitted as UTC midnight, making the calendar date the source of truth
- Both frontend and backend now consistently use UTC for date operations, preventing timezone-related data corruption

https://claude.ai/code/session_01AZaeWDwAK9qCwysSmwqDKq