### PR TITLE
Add Light / Dark / Automatic theme selector

### DIFF
--- a/web/static/css/layout.css
+++ b/web/static/css/layout.css
@@ -44,8 +44,41 @@
   --color-danger-bg: #dc2626;
   --color-danger-hover: #b91c1c;
   --color-on-danger: #fff;
+  --color-success-bg: #f0fdf4;
+  --color-success-border: #bbf7d0;
+  --color-success-text: #15803d;
   --shadow-1: 0 1px 3px rgb(0 0 0 / 8%), 0 1px 2px rgb(0 0 0 / 5%);
   --shadow-2: 0 4px 6px rgb(0 0 0 / 7%), 0 2px 4px rgb(0 0 0 / 5%);
+}
+
+html.theme-dark {
+  --color-bg: #0f172a;
+  --color-surface: #1e293b;
+  --color-surface-muted: #18243a;
+  --color-surface-hover: #273548;
+  --color-text: #e2e8f0;
+  --color-text-muted: #94a3b8;
+  --color-input-placeholder: #64748b;
+  --color-chip-text: #cbd5e1;
+  --color-chip-bg: #273548;
+  --color-chip-border: #334155;
+  --color-border: #334155;
+  --color-border-strong: #475569;
+  --color-focus: #22c55e;
+  --color-danger: #f87171;
+  --color-primary: #22c55e;
+  --color-primary-hover: #16a34a;
+  --color-on-primary: #052e16;
+  --color-neutral: #273548;
+  --color-neutral-hover: #334155;
+  --color-danger-bg: #dc2626;
+  --color-danger-hover: #ef4444;
+  --color-on-danger: #fff;
+  --color-success-bg: #14321f;
+  --color-success-border: #166534;
+  --color-success-text: #86efac;
+  --shadow-1: 0 1px 3px rgb(0 0 0 / 40%), 0 1px 2px rgb(0 0 0 / 30%);
+  --shadow-2: 0 4px 6px rgb(0 0 0 / 40%), 0 2px 4px rgb(0 0 0 / 30%);
 }
 
 html {
@@ -361,9 +394,9 @@ td form {
 }
 
 .chip-tag {
-  border-color: #bbf7d0;
-  background: #f0fdf4;
-  color: #15803d;
+  border-color: var(--color-success-border);
+  background: var(--color-success-bg);
+  color: var(--color-success-text);
 }
 
 .chart-container {
@@ -465,13 +498,13 @@ button:focus-visible {
   outline-offset: 2px;
 }
 
-.theme-light .page-shell {
+.page-shell {
   width: min(100%, var(--size-content));
   margin-inline: auto;
   padding: var(--space-6) var(--space-4) var(--space-7);
 }
 
-.theme-light .site-header {
+.site-header {
   display: flex;
   align-items: center;
   gap: var(--space-3);
@@ -482,7 +515,7 @@ button:focus-visible {
   border-radius: var(--radius-1);
 }
 
-.theme-light .site-brand {
+.site-brand {
   font-size: var(--font-size-3);
   font-weight: 700;
   letter-spacing: 0.04em;
@@ -491,11 +524,11 @@ button:focus-visible {
   margin-right: auto;
 }
 
-.theme-light .site-nav {
+.site-nav {
   position: relative;
 }
 
-.theme-light .site-nav-toggle {
+.site-nav-toggle {
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
@@ -511,16 +544,33 @@ button:focus-visible {
   cursor: pointer;
 }
 
-.theme-light .site-nav-toggle:hover {
+.site-nav-toggle:hover {
   background: var(--color-neutral-hover);
 }
 
-.theme-light .site-nav-caret {
+.theme-switch select {
+  width: auto;
+  min-height: unset;
+  padding: var(--space-2) var(--space-3);
+  font-size: var(--font-size-1);
+  font-weight: 500;
+  color: var(--color-text);
+  background: var(--color-neutral);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-1);
+  cursor: pointer;
+}
+
+.theme-switch select:hover {
+  background: var(--color-neutral-hover);
+}
+
+.site-nav-caret {
   font-size: 0.7em;
   line-height: 1;
 }
 
-.theme-light .site-nav-dropdown {
+.site-nav-dropdown {
   display: none;
   position: absolute;
   top: calc(100% + var(--space-2));
@@ -535,11 +585,11 @@ button:focus-visible {
   box-shadow: 0 4px 12px rgb(0 0 0 / 8%);
 }
 
-.theme-light .site-nav-dropdown.open {
+.site-nav-dropdown.open {
   display: block;
 }
 
-.theme-light .site-nav-dropdown li a {
+.site-nav-dropdown li a {
   display: block;
   padding: var(--space-2) var(--space-4);
   font-size: var(--font-size-1);
@@ -547,24 +597,24 @@ button:focus-visible {
   text-decoration: none;
 }
 
-.theme-light .site-nav-dropdown li a:hover {
+.site-nav-dropdown li a:hover {
   background: var(--color-surface-hover);
   color: var(--color-primary);
 }
 
-.theme-light .site-nav-divider {
+.site-nav-divider {
   height: 1px;
   margin: var(--space-2) 0;
   background: var(--color-border);
 }
 
-.theme-light .site-nav-logout {
+.site-nav-logout {
   display: block;
   margin: 0;
   max-width: none;
 }
 
-.theme-light .site-nav-logout-btn {
+.site-nav-logout-btn {
   display: block;
   width: 100%;
   min-height: unset;
@@ -579,17 +629,17 @@ button:focus-visible {
   cursor: pointer;
 }
 
-.theme-light .site-nav-logout-btn:hover {
+.site-nav-logout-btn:hover {
   background: var(--color-surface-hover);
 }
 
-.theme-light .page-main {
+.page-main {
   display: grid;
   gap: var(--space-5);
 }
 
-.theme-light .page-main > form,
-.theme-light .page-main > .form-stack {
+.page-main > form,
+.page-main > .form-stack {
   max-width: var(--size-form);
 }
 
@@ -598,12 +648,12 @@ p[style*="color: red"] {
 }
 
 @media (width <= 48rem) {
-  .theme-light .page-shell {
+  .page-shell {
     padding-top: var(--space-5);
     padding-bottom: var(--space-6);
   }
 
-  .theme-light .page-main {
+  .page-main {
     gap: var(--space-4);
   }
 

--- a/web/static/js/controllers/themeController.ts
+++ b/web/static/js/controllers/themeController.ts
@@ -1,0 +1,47 @@
+import { Controller } from "@hotwired/stimulus";
+
+type Theme = "light" | "dark" | "auto";
+
+const STORAGE_KEY = "theme";
+
+export default class extends Controller {
+  static targets = ["select"];
+  declare readonly selectTarget: HTMLSelectElement;
+
+  private media = window.matchMedia("(prefers-color-scheme: dark)");
+
+  private handleSystemChange = () => {
+    if (this.preference() === "auto") {
+      this.apply("auto");
+    }
+  };
+
+  connect() {
+    this.selectTarget.value = this.preference();
+    this.apply(this.preference());
+    this.media.addEventListener("change", this.handleSystemChange);
+  }
+
+  disconnect() {
+    this.media.removeEventListener("change", this.handleSystemChange);
+  }
+
+  change() {
+    const value = this.selectTarget.value as Theme;
+    localStorage.setItem(STORAGE_KEY, value);
+    this.apply(value);
+  }
+
+  private preference(): Theme {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored === "light" || stored === "dark" || stored === "auto") {
+      return stored;
+    }
+    return "auto";
+  }
+
+  private apply(theme: Theme) {
+    const dark = theme === "dark" || (theme === "auto" && this.media.matches);
+    document.documentElement.className = dark ? "theme-dark" : "theme-light";
+  }
+}

--- a/web/static/js/index.ts
+++ b/web/static/js/index.ts
@@ -21,6 +21,7 @@ import LocalDateController from "./controllers/localDateController";
 import MacroCalcController from "./controllers/macroCalcController";
 import MacroTrendController from "./controllers/macroTrendController";
 import MoodChartController from "./controllers/moodChartController";
+import ThemeController from "./controllers/themeController";
 import { initIcons } from "./icons";
 
 window.Stimulus = Application.start();
@@ -37,5 +38,6 @@ window.Stimulus.register("local-date", LocalDateController);
 window.Stimulus.register("macro-calc", MacroCalcController);
 window.Stimulus.register("macro-trend", MacroTrendController);
 window.Stimulus.register("mood-chart", MoodChartController);
+window.Stimulus.register("theme", ThemeController);
 
 document.addEventListener("turbo:load", initIcons);

--- a/web/views/common/_header.html
+++ b/web/views/common/_header.html
@@ -1,6 +1,14 @@
 {{ define "header" }}
   <header class="site-header">
     <a href="/" class="site-brand">NINETE</a>
+    <label class="theme-switch" data-controller="theme">
+      <span class="sr-only">Theme</span>
+      <select data-theme-target="select" data-action="change->theme#change">
+        <option value="auto">Automatic</option>
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+      </select>
+    </label>
     {{ if ne .currentUser nil }}
       <nav class="site-nav" data-controller="nav">
         <button

--- a/web/views/layout.html
+++ b/web/views/layout.html
@@ -1,10 +1,24 @@
 {{ define "layout" }}
   <!doctype html>
-  <html lang="en">
+  <html lang="en" class="theme-light">
     <head>
       <meta charset="UTF-8" />
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+      <script>
+        (function () {
+          try {
+            var pref = localStorage.getItem("theme") || "auto";
+            var dark =
+              pref === "dark" ||
+              (pref === "auto" &&
+                window.matchMedia("(prefers-color-scheme: dark)").matches);
+            document.documentElement.className = dark
+              ? "theme-dark"
+              : "theme-light";
+          } catch (e) {}
+        })();
+      </script>
       <link rel="icon" type="image/x-icon" href="/static/img/favicon.ico" />
       <link
         rel="stylesheet"
@@ -18,7 +32,7 @@
       ></script>
       <title>NINETE</title>
     </head>
-    <body class="theme-light" hx-boost="true">
+    <body hx-boost="true">
       <div class="page-shell">
         {{ template "header" . }}
         <main class="page-main">


### PR DESCRIPTION
## Summary
Adds a theme selector (Light / Dark / Automatic) available on every page, including for signed-out users on `/login` and `/register`. Preference is stored in `localStorage` (no DB changes).

## Changes
- **`web/views/layout.html`**: theme class moved to `<html>`; inline `<head>` script resolves the stored preference (and `auto` via `prefers-color-scheme`) before first paint to avoid a flash of the wrong theme.
- **`web/static/css/layout.css`**: added an `html.theme-dark` block overriding the existing `--color-*` variables with a dark palette; de-scoped the ~18 `.theme-light`-prefixed structural rules so they adapt via CSS variables; replaced hardcoded `.chip-tag` greens with new `--color-success-*` variables (light + dark); styled the `.theme-switch` control.
- **`web/views/common/_header.html`**: always-visible native `<select>` (Automatic / Light / Dark) in the header.
- **`web/static/js/controllers/themeController.ts`** (new) + registered in `index.ts`: restores the saved preference, applies the resolved theme, persists on change, and reacts live to OS changes while in `Automatic`.

## Testing
- `make build-static-js`, `make lint-fix` (clean), `make test` (all packages pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)