### PR TITLE
Fix mobile logout: use SameSite=Lax for session cookie

### DIFF
--- a/internal/serve/routes.go
+++ b/internal/serve/routes.go
@@ -112,6 +112,6 @@ func (s *Server) setUpSession() {
 	s.Session.Cookie.Secure = s.app.IsProduction()
 	s.Session.Cookie.HttpOnly = true
 	s.Session.Cookie.Persist = true
-	s.Session.Cookie.SameSite = http.SameSiteStrictMode
+	s.Session.Cookie.SameSite = http.SameSiteLaxMode
 	s.Session.Cookie.Name = "ninete_session"
 }


### PR DESCRIPTION
## Summary
Changes the session cookie's `SameSite` policy from `Strict` to `Lax` to fix users being unexpectedly redirected to `/login` on mobile.

## Why
With `SameSite=Strict`, the browser only sends the session cookie when the navigation originates from the same site. On mobile (observed in Brave on iOS), this withholds the cookie on common top-level navigations:
- iOS aggressively discards background tabs; returning to the tab reloads it as a fresh top-level navigation with no same-site initiator → cookie withheld → login page.
- Pull-to-refresh is treated as a navigation without a same-site referrer in several mobile browsers → cookie withheld → login page.

Desktop never reproduces it because the tab stays alive and keeps a same-site context.

`Lax` sends the cookie on top-level GET navigations (refreshes, bookmarks, external links, tab restores) while still withholding it on cross-site sub-requests and cross-site POSTs, preserving CSRF protection. This also makes the session cookie consistent with the CSRF cookie, which is already `Lax` (`internal/serve/middleware.go`).

## Change
- `internal/serve/routes.go`: `http.SameSiteStrictMode` → `http.SameSiteLaxMode`.

## Testing
- `make lint-fix` (clean), `make test` (all packages pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)