### PR TITLE
Add account page to bulk-delete user data

### DIFF
--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -23,6 +23,9 @@ const (
 type TemplateName string
 
 const (
+	// Account templates.
+	AccountIndex TemplateName = "account/index"
+
 	// Dashboard templates.
 	DashboardIndex TemplateName = "dashboard/index"
 

--- a/internal/handlers/handle_account.go
+++ b/internal/handlers/handle_account.go
@@ -1,0 +1,126 @@
+package handlers
+
+import (
+	"net/http"
+)
+
+func (h *Handler) GetAccount(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	data := h.tmplData(r)
+	user := getCurrentUser(r)
+
+	counts, err := h.store.FindAccountDataCounts(ctx, user.ID)
+	if err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, AccountIndex, err)
+
+		return
+	}
+
+	data["counts"] = counts
+
+	h.render(w, http.StatusOK, AccountIndex, data)
+}
+
+func (h *Handler) PostAccountDeleteExpenses(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := getCurrentUser(r)
+
+	if err := h.store.DeleteAllExpenses(ctx, user.ID); err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, ErrorIndex, err)
+
+		return
+	}
+
+	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}
+
+func (h *Handler) PostAccountDeleteRecurrentExpenses(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := getCurrentUser(r)
+
+	if err := h.store.DeleteAllRecurrentExpenses(ctx, user.ID); err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, ErrorIndex, err)
+
+		return
+	}
+
+	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}
+
+func (h *Handler) PostAccountDeleteMacroEntries(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := getCurrentUser(r)
+
+	if err := h.store.DeleteAllMacroEntries(ctx, user.ID); err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, ErrorIndex, err)
+
+		return
+	}
+
+	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}
+
+func (h *Handler) PostAccountDeleteMacroGoals(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := getCurrentUser(r)
+
+	if err := h.store.DeleteAllMacroGoals(ctx, user.ID); err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, ErrorIndex, err)
+
+		return
+	}
+
+	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}
+
+func (h *Handler) PostAccountDeleteFoods(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := getCurrentUser(r)
+
+	if err := h.store.DeleteAllFoods(ctx, user.ID); err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, ErrorIndex, err)
+
+		return
+	}
+
+	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}
+
+func (h *Handler) PostAccountDeleteMoodEntries(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := getCurrentUser(r)
+
+	if err := h.store.DeleteAllMoodEntries(ctx, user.ID); err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, ErrorIndex, err)
+
+		return
+	}
+
+	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}
+
+func (h *Handler) PostAccountDeleteTags(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := getCurrentUser(r)
+
+	if err := h.store.DeleteAllTags(ctx, user.ID); err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, ErrorIndex, err)
+
+		return
+	}
+
+	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}
+
+func (h *Handler) PostAccountDeleteAll(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := getCurrentUser(r)
+
+	if err := h.store.DeleteAllUserData(ctx, user.ID); err != nil {
+		h.renderErr(w, r, http.StatusInternalServerError, ErrorIndex, err)
+
+		return
+	}
+
+	http.Redirect(w, r, "/account", http.StatusSeeOther)
+}

--- a/internal/handlers/handle_account_test.go
+++ b/internal/handlers/handle_account_test.go
@@ -1,0 +1,111 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ad9311/ninete/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAccount(t *testing.T) {
+	s := spec.New(t)
+	handler := s.WrappedHandler()
+
+	cases := []struct {
+		name string
+		fn   func(*testing.T)
+	}{
+		{
+			name: "should_redirect_to_login_when_unauthenticated",
+			fn: func(t *testing.T) {
+				req := spec.NewGetRequest("/account", nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				require.Equal(t, http.StatusSeeOther, rec.Code)
+				require.Equal(t, "/login", rec.Header().Get("Location"))
+			},
+		},
+		{
+			name: "should_render_account_page_with_counts",
+			fn: func(t *testing.T) {
+				user := s.CreateAuthUser(t, "acct_page_1", "acct_page_1@example.com", "acct_password_1")
+				category := s.CreateCategory(t, "acct page category")
+				s.CreateExpense(t, user.ID, newExpenseParams(category.ID, "acct page expense", 500, 1735689600))
+				cookies := s.AuthCookies(t, "acct_page_1@example.com", "acct_password_1")
+
+				req := spec.NewGetRequest("/account", cookies)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				require.Equal(t, http.StatusOK, rec.Code)
+				body := rec.Body.String()
+				require.Contains(t, body, "Account")
+				require.Contains(t, body, "Delete everything")
+				require.Contains(t, body, "1 record(s)")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, tc.fn)
+	}
+}
+
+func TestPostAccountDeleteExpenses(t *testing.T) {
+	s := spec.New(t)
+	handler := s.WrappedHandler()
+
+	user := s.CreateAuthUser(t, "acct_del_exp", "acct_del_exp@example.com", "acct_password_1")
+	category := s.CreateCategory(t, "acct del exp category")
+	s.CreateExpense(t, user.ID, newExpenseParams(category.ID, "expense to wipe", 500, 1735689600))
+	cookies := s.AuthCookies(t, "acct_del_exp@example.com", "acct_password_1")
+	csrfToken, cookies := s.CSRFFrom(t, "/account", cookies)
+
+	req := spec.NewPostRequest("/account/expenses/delete-all", "", cookies, csrfToken)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusSeeOther, rec.Code)
+	require.Equal(t, "/account", rec.Header().Get("Location"))
+
+	count, err := s.Queries.CountExpensesByUser(t.Context(), user.ID)
+	require.NoError(t, err)
+	require.Zero(t, count)
+}
+
+func TestPostAccountDeleteAll(t *testing.T) {
+	s := spec.New(t)
+	handler := s.WrappedHandler()
+
+	user := s.CreateAuthUser(t, "acct_del_all", "acct_del_all@example.com", "acct_password_1")
+	otherUser := s.CreateAuthUser(t, "acct_del_all_other", "acct_del_all_other@example.com", "acct_password_2")
+	category := s.CreateCategory(t, "acct del all category")
+
+	s.CreateExpense(t, user.ID, newExpenseParams(category.ID, "mine", 500, 1735689600))
+	s.CreateMoodEntry(t, user.ID, newMoodEntryParamsH("Happy", "mine", 1735689600, []string{"acct_wipe_tag"}))
+	s.CreateExpense(t, otherUser.ID, newExpenseParams(category.ID, "theirs", 600, 1735689600))
+
+	cookies := s.AuthCookies(t, "acct_del_all@example.com", "acct_password_1")
+	csrfToken, cookies := s.CSRFFrom(t, "/account", cookies)
+
+	req := spec.NewPostRequest("/account/delete-all", "", cookies, csrfToken)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusSeeOther, rec.Code)
+	require.Equal(t, "/account", rec.Header().Get("Location"))
+
+	counts, err := s.Store.FindAccountDataCounts(t.Context(), user.ID)
+	require.NoError(t, err)
+	require.Equal(t, 0, counts.Expenses)
+	require.Equal(t, 0, counts.MoodEntries)
+	require.Equal(t, 0, counts.Tags)
+
+	// The other user's data must remain intact.
+	otherCount, err := s.Queries.CountExpensesByUser(t.Context(), otherUser.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, otherCount)
+}

--- a/internal/logic/logic_account.go
+++ b/internal/logic/logic_account.go
@@ -1,0 +1,77 @@
+package logic
+
+import (
+	"context"
+
+	"github.com/ad9311/ninete/internal/repo"
+)
+
+// AccountDataCounts holds the number of records a user owns per model type,
+// used to populate the account "danger zone" page.
+type AccountDataCounts struct {
+	Expenses          int
+	RecurrentExpenses int
+	MacroEntries      int
+	MacroGoals        int
+	Foods             int
+	MoodEntries       int
+	Tags              int
+}
+
+// FindAccountDataCounts returns per-model record counts for the given user.
+func (s *Store) FindAccountDataCounts(ctx context.Context, userID int) (AccountDataCounts, error) {
+	var counts AccountDataCounts
+	var err error
+
+	if counts.Expenses, err = s.queries.CountExpensesByUser(ctx, userID); err != nil {
+		return counts, err
+	}
+	if counts.RecurrentExpenses, err = s.queries.CountRecurrentExpensesByUser(ctx, userID); err != nil {
+		return counts, err
+	}
+	if counts.MacroEntries, err = s.queries.CountMacroEntriesByUser(ctx, userID); err != nil {
+		return counts, err
+	}
+	if counts.MacroGoals, err = s.queries.CountMacroGoalsByUser(ctx, userID); err != nil {
+		return counts, err
+	}
+	if counts.Foods, err = s.queries.CountFoodsByUser(ctx, userID); err != nil {
+		return counts, err
+	}
+	if counts.MoodEntries, err = s.queries.CountMoodEntriesByUser(ctx, userID); err != nil {
+		return counts, err
+	}
+	if counts.Tags, err = s.queries.CountTagsByUser(ctx, userID); err != nil {
+		return counts, err
+	}
+
+	return counts, nil
+}
+
+// DeleteAllUserData removes every record owned by the user across all model
+// types in a single transaction (all-or-nothing). Tags are deleted last so any
+// remaining taggings cascade away via their tag_id foreign key.
+func (s *Store) DeleteAllUserData(ctx context.Context, userID int) error {
+	return s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		if err := tq.DeleteAllExpensesByUser(ctx, userID); err != nil {
+			return err
+		}
+		if err := tq.DeleteAllRecurrentExpensesByUser(ctx, userID); err != nil {
+			return err
+		}
+		if err := tq.DeleteAllMacroEntriesByUser(ctx, userID); err != nil {
+			return err
+		}
+		if err := tq.DeleteAllMacroGoalsByUser(ctx, userID); err != nil {
+			return err
+		}
+		if err := tq.DeleteAllFoodsByUser(ctx, userID); err != nil {
+			return err
+		}
+		if err := tq.DeleteAllMoodEntriesByUser(ctx, userID); err != nil {
+			return err
+		}
+
+		return tq.DeleteAllTagsByUser(ctx, userID)
+	})
+}

--- a/internal/logic/logic_account_test.go
+++ b/internal/logic/logic_account_test.go
@@ -1,0 +1,156 @@
+package logic_test
+
+import (
+	"testing"
+
+	"github.com/ad9311/ninete/internal/logic"
+	"github.com/ad9311/ninete/internal/repo"
+	"github.com/ad9311/ninete/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteAllExpenses(t *testing.T) {
+	s := spec.New(t)
+	ctx := t.Context()
+
+	user := s.CreateAuthUser(t, "acct_exp_user", "acct_exp_user@example.com", "password_1")
+	otherUser := s.CreateAuthUser(t, "acct_exp_other", "acct_exp_other@example.com", "password_2")
+	category := s.CreateCategory(t, "acct expense category")
+
+	userExpense := s.CreateExpense(
+		t, user.ID,
+		newExpenseParams(category.ID, "acct user expense", 500, 1735689600, []string{"acct_tag_a"}),
+	)
+	otherExpense := s.CreateExpense(
+		t, otherUser.ID,
+		newExpenseParams(category.ID, "acct other expense", 600, 1735689600, []string{"acct_tag_b"}),
+	)
+
+	err := s.Store.DeleteAllExpenses(ctx, user.ID)
+	require.NoError(t, err)
+
+	userCount, err := s.Queries.CountExpensesByUser(ctx, user.ID)
+	require.NoError(t, err)
+	require.Zero(t, userCount)
+
+	// Taggings for the deleted expense must not be orphaned.
+	orphaned, err := s.Queries.CountTaggingsByTarget(ctx, repo.TaggableTypeExpense, userExpense.ID)
+	require.NoError(t, err)
+	require.Zero(t, orphaned)
+
+	// The user's tags themselves survive (only taggings are cleaned).
+	tagCount, err := s.Queries.CountTagsByUser(ctx, user.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, tagCount)
+
+	// The other user's data is untouched.
+	otherCount, err := s.Queries.CountExpensesByUser(ctx, otherUser.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, otherCount)
+
+	otherTaggings, err := s.Queries.CountTaggingsByTarget(ctx, repo.TaggableTypeExpense, otherExpense.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, otherTaggings)
+}
+
+func TestDeleteAllMoodEntries(t *testing.T) {
+	s := spec.New(t)
+	ctx := t.Context()
+
+	user := s.CreateAuthUser(t, "acct_mood_user", "acct_mood_user@example.com", "password_1")
+	otherUser := s.CreateAuthUser(t, "acct_mood_other", "acct_mood_other@example.com", "password_2")
+
+	userMood := s.CreateMoodEntry(
+		t, user.ID,
+		newMoodEntryParams("Happy", "acct notes", 1735689600, []string{"acct_mood_tag"}),
+	)
+	s.CreateMoodEntry(
+		t, otherUser.ID,
+		newMoodEntryParams("Calm", "acct other notes", 1735689600, []string{"acct_mood_tag_b"}),
+	)
+
+	err := s.Store.DeleteAllMoodEntries(ctx, user.ID)
+	require.NoError(t, err)
+
+	userCount, err := s.Queries.CountMoodEntriesByUser(ctx, user.ID)
+	require.NoError(t, err)
+	require.Zero(t, userCount)
+
+	orphaned, err := s.Queries.CountTaggingsByTarget(ctx, repo.TaggableTypeMoodEntry, userMood.ID)
+	require.NoError(t, err)
+	require.Zero(t, orphaned)
+
+	otherCount, err := s.Queries.CountMoodEntriesByUser(ctx, otherUser.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, otherCount)
+}
+
+func TestDeleteAllTagsCascadesTaggings(t *testing.T) {
+	s := spec.New(t)
+	ctx := t.Context()
+
+	user := s.CreateAuthUser(t, "acct_tag_user", "acct_tag_user@example.com", "password_1")
+	category := s.CreateCategory(t, "acct tag category")
+
+	expense := s.CreateExpense(
+		t, user.ID,
+		newExpenseParams(category.ID, "acct tag expense", 500, 1735689600, []string{"acct_del_tag"}),
+	)
+
+	err := s.Store.DeleteAllTags(ctx, user.ID)
+	require.NoError(t, err)
+
+	tagCount, err := s.Queries.CountTagsByUser(ctx, user.ID)
+	require.NoError(t, err)
+	require.Zero(t, tagCount)
+
+	// Deleting tags cascades their taggings via the tag_id FK.
+	taggings, err := s.Queries.CountTaggingsByTarget(ctx, repo.TaggableTypeExpense, expense.ID)
+	require.NoError(t, err)
+	require.Zero(t, taggings)
+}
+
+func TestDeleteAllUserData(t *testing.T) {
+	s := spec.New(t)
+	ctx := t.Context()
+
+	user := s.CreateAuthUser(t, "acct_all_user", "acct_all_user@example.com", "password_1")
+	otherUser := s.CreateAuthUser(t, "acct_all_other", "acct_all_other@example.com", "password_2")
+	category := s.CreateCategory(t, "acct all category")
+
+	seed := func(userID int, suffix string) {
+		s.CreateExpense(t, userID, newExpenseParams(category.ID, "exp "+suffix, 500, 1735689600, []string{"tag_" + suffix}))
+		s.CreateRecurrentExpense(t, userID, newRecurrentExpenseParams(category.ID, "rec "+suffix, 500, 1))
+		s.CreateMacroEntry(t, userID, newMacroEntryParams("macro "+suffix, 100, 10, 10, 5, 1735689600))
+		s.SaveMacroGoal(t, userID, logic.MacroGoalParams{Kcal: 2000, ProteinG: 150, CarbsG: 200, FatG: 70})
+		s.CreateFood(t, userID, newFoodParams("food "+suffix, 100, 10, 10, 5))
+		s.CreateMoodEntry(t, userID, newMoodEntryParams("Happy", "notes "+suffix, 1735689600, []string{"mtag_" + suffix}))
+	}
+
+	seed(user.ID, "user")
+	seed(otherUser.ID, "other")
+
+	err := s.Store.DeleteAllUserData(ctx, user.ID)
+	require.NoError(t, err)
+
+	counts, err := s.Store.FindAccountDataCounts(ctx, user.ID)
+	require.NoError(t, err)
+	require.Equal(t, 0, counts.Expenses)
+	require.Equal(t, 0, counts.RecurrentExpenses)
+	require.Equal(t, 0, counts.MacroEntries)
+	require.Equal(t, 0, counts.MacroGoals)
+	require.Equal(t, 0, counts.Foods)
+	require.Equal(t, 0, counts.MoodEntries)
+	require.Equal(t, 0, counts.Tags)
+
+	otherCounts, err := s.Store.FindAccountDataCounts(ctx, otherUser.ID)
+	require.NoError(t, err)
+	require.Equal(t, 1, otherCounts.Expenses)
+	require.Equal(t, 1, otherCounts.RecurrentExpenses)
+	require.Equal(t, 1, otherCounts.MacroEntries)
+	require.Equal(t, 1, otherCounts.MacroGoals)
+	require.Equal(t, 1, otherCounts.Foods)
+	require.Equal(t, 1, otherCounts.MoodEntries)
+	// Two tags per seed: one from the expense, one from the mood entry.
+	require.Equal(t, 2, otherCounts.Tags)
+}

--- a/internal/logic/logic_expense.go
+++ b/internal/logic/logic_expense.go
@@ -117,6 +117,12 @@ func (s *Store) DeleteExpense(ctx context.Context, id, userID int) (int, error) 
 	return i, nil
 }
 
+func (s *Store) DeleteAllExpenses(ctx context.Context, userID int) error {
+	return s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		return tq.DeleteAllExpensesByUser(ctx, userID)
+	})
+}
+
 func (s *Store) FindExpensesCategoryTotals(
 	ctx context.Context,
 	filters repo.Filters,

--- a/internal/logic/logic_food.go
+++ b/internal/logic/logic_food.go
@@ -109,3 +109,9 @@ func (s *Store) DeleteFood(ctx context.Context, id, userID int) (int, error) {
 
 	return i, nil
 }
+
+func (s *Store) DeleteAllFoods(ctx context.Context, userID int) error {
+	return s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		return tq.DeleteAllFoodsByUser(ctx, userID)
+	})
+}

--- a/internal/logic/logic_macro.go
+++ b/internal/logic/logic_macro.go
@@ -141,6 +141,18 @@ func (s *Store) DeleteMacroEntry(ctx context.Context, id, userID int) (int, erro
 	return i, nil
 }
 
+func (s *Store) DeleteAllMacroEntries(ctx context.Context, userID int) error {
+	return s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		return tq.DeleteAllMacroEntriesByUser(ctx, userID)
+	})
+}
+
+func (s *Store) DeleteAllMacroGoals(ctx context.Context, userID int) error {
+	return s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		return tq.DeleteAllMacroGoalsByUser(ctx, userID)
+	})
+}
+
 func (s *Store) FindMacroDayTotals(
 	ctx context.Context,
 	userID int,

--- a/internal/logic/logic_mood_entry.go
+++ b/internal/logic/logic_mood_entry.go
@@ -128,3 +128,9 @@ func (s *Store) DeleteMoodEntry(ctx context.Context, id, userID int) error {
 
 	return nil
 }
+
+func (s *Store) DeleteAllMoodEntries(ctx context.Context, userID int) error {
+	return s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		return tq.DeleteAllMoodEntriesByUser(ctx, userID)
+	})
+}

--- a/internal/logic/logic_recurrent_expense.go
+++ b/internal/logic/logic_recurrent_expense.go
@@ -103,6 +103,12 @@ func (s *Store) DeleteRecurrentExpense(ctx context.Context, id, userID int) (int
 	return i, nil
 }
 
+func (s *Store) DeleteAllRecurrentExpenses(ctx context.Context, userID int) error {
+	return s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		return tq.DeleteAllRecurrentExpensesByUser(ctx, userID)
+	})
+}
+
 func (s *Store) CopyDueRecurrentExpenses(ctx context.Context, now time.Time) (int, error) {
 	nowUnix := now.Unix()
 	expenseDate := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).Unix()

--- a/internal/logic/logic_tag.go
+++ b/internal/logic/logic_tag.go
@@ -49,6 +49,12 @@ func (s *Store) DeleteTag(ctx context.Context, id, userID int) (int, error) {
 	return i, nil
 }
 
+func (s *Store) DeleteAllTags(ctx context.Context, userID int) error {
+	return s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		return tq.DeleteAllTagsByUser(ctx, userID)
+	})
+}
+
 func ParseTagNames(raw string) []string {
 	rawTags := strings.Split(raw, ";")
 

--- a/internal/repo/expense.go
+++ b/internal/repo/expense.go
@@ -289,6 +289,39 @@ func (q *Queries) DeleteExpense(ctx context.Context, id, userID int) (int, error
 	return i, err
 }
 
+const countExpensesByUser = `SELECT COUNT(*) FROM "expenses" WHERE "user_id" = ?`
+
+func (q *Queries) CountExpensesByUser(ctx context.Context, userID int) (int, error) {
+	var c int
+
+	err := q.wrapQuery(countExpensesByUser, func() error {
+		row := q.db.QueryRowContext(ctx, countExpensesByUser, userID)
+
+		return row.Scan(&c)
+	})
+
+	return c, err
+}
+
+const deleteExpenseTaggingsByUser = `
+DELETE FROM "taggings"
+WHERE "taggable_type" = 'expense'
+  AND "taggable_id" IN (SELECT "id" FROM "expenses" WHERE "user_id" = ?)`
+
+const deleteAllExpensesByUser = `DELETE FROM "expenses" WHERE "user_id" = ?`
+
+func (q *TxQueries) DeleteAllExpensesByUser(ctx context.Context, userID int) error {
+	return q.wrapQuery(deleteAllExpensesByUser, func() error {
+		if _, err := q.tx.ExecContext(ctx, deleteExpenseTaggingsByUser, userID); err != nil {
+			return err
+		}
+
+		_, err := q.tx.ExecContext(ctx, deleteAllExpensesByUser, userID)
+
+		return err
+	})
+}
+
 const selectExpensesCategoryTotals = `
 SELECT "category_id", SUM("amount") AS "total"
 FROM "expenses"

--- a/internal/repo/food.go
+++ b/internal/repo/food.go
@@ -243,6 +243,30 @@ func (q *Queries) DeleteFood(ctx context.Context, id, userID int) (int, error) {
 	return i, err
 }
 
+const countFoodsByUser = `SELECT COUNT(*) FROM "foods" WHERE "user_id" = ?`
+
+func (q *Queries) CountFoodsByUser(ctx context.Context, userID int) (int, error) {
+	var c int
+
+	err := q.wrapQuery(countFoodsByUser, func() error {
+		row := q.db.QueryRowContext(ctx, countFoodsByUser, userID)
+
+		return row.Scan(&c)
+	})
+
+	return c, err
+}
+
+const deleteAllFoodsByUser = `DELETE FROM "foods" WHERE "user_id" = ?`
+
+func (q *TxQueries) DeleteAllFoodsByUser(ctx context.Context, userID int) error {
+	return q.wrapQuery(deleteAllFoodsByUser, func() error {
+		_, err := q.tx.ExecContext(ctx, deleteAllFoodsByUser, userID)
+
+		return err
+	})
+}
+
 func validFoodFields() []string {
 	return []string{
 		"id",

--- a/internal/repo/macro_entry.go
+++ b/internal/repo/macro_entry.go
@@ -303,6 +303,30 @@ func (q *Queries) DeleteMacroEntry(ctx context.Context, id, userID int) (int, er
 	return i, err
 }
 
+const countMacroEntriesByUser = `SELECT COUNT(*) FROM "macro_entries" WHERE "user_id" = ?`
+
+func (q *Queries) CountMacroEntriesByUser(ctx context.Context, userID int) (int, error) {
+	var c int
+
+	err := q.wrapQuery(countMacroEntriesByUser, func() error {
+		row := q.db.QueryRowContext(ctx, countMacroEntriesByUser, userID)
+
+		return row.Scan(&c)
+	})
+
+	return c, err
+}
+
+const deleteAllMacroEntriesByUser = `DELETE FROM "macro_entries" WHERE "user_id" = ?`
+
+func (q *TxQueries) DeleteAllMacroEntriesByUser(ctx context.Context, userID int) error {
+	return q.wrapQuery(deleteAllMacroEntriesByUser, func() error {
+		_, err := q.tx.ExecContext(ctx, deleteAllMacroEntriesByUser, userID)
+
+		return err
+	})
+}
+
 const selectMacroDayTotals = `
 SELECT COALESCE(SUM("kcal"),0), COALESCE(SUM("protein_g"),0),
        COALESCE(SUM("carbs_g"),0), COALESCE(SUM("fat_g"),0),

--- a/internal/repo/macro_goal.go
+++ b/internal/repo/macro_goal.go
@@ -104,3 +104,27 @@ func (q *TxQueries) UpsertMacroGoal(ctx context.Context, params UpsertMacroGoalP
 
 	return g, err
 }
+
+const countMacroGoalsByUser = `SELECT COUNT(*) FROM "macro_goals" WHERE "user_id" = ?`
+
+func (q *Queries) CountMacroGoalsByUser(ctx context.Context, userID int) (int, error) {
+	var c int
+
+	err := q.wrapQuery(countMacroGoalsByUser, func() error {
+		row := q.db.QueryRowContext(ctx, countMacroGoalsByUser, userID)
+
+		return row.Scan(&c)
+	})
+
+	return c, err
+}
+
+const deleteAllMacroGoalsByUser = `DELETE FROM "macro_goals" WHERE "user_id" = ?`
+
+func (q *TxQueries) DeleteAllMacroGoalsByUser(ctx context.Context, userID int) error {
+	return q.wrapQuery(deleteAllMacroGoalsByUser, func() error {
+		_, err := q.tx.ExecContext(ctx, deleteAllMacroGoalsByUser, userID)
+
+		return err
+	})
+}

--- a/internal/repo/mood_entry.go
+++ b/internal/repo/mood_entry.go
@@ -211,6 +211,39 @@ func (q *Queries) DeleteMoodEntry(ctx context.Context, id, userID int) (int, err
 	return i, err
 }
 
+const countMoodEntriesByUser = `SELECT COUNT(*) FROM "mood_entries" WHERE "user_id" = ?`
+
+func (q *Queries) CountMoodEntriesByUser(ctx context.Context, userID int) (int, error) {
+	var c int
+
+	err := q.wrapQuery(countMoodEntriesByUser, func() error {
+		row := q.db.QueryRowContext(ctx, countMoodEntriesByUser, userID)
+
+		return row.Scan(&c)
+	})
+
+	return c, err
+}
+
+const deleteMoodEntryTaggingsByUser = `
+DELETE FROM "taggings"
+WHERE "taggable_type" = 'mood_entry'
+  AND "taggable_id" IN (SELECT "id" FROM "mood_entries" WHERE "user_id" = ?)`
+
+const deleteAllMoodEntriesByUser = `DELETE FROM "mood_entries" WHERE "user_id" = ?`
+
+func (q *TxQueries) DeleteAllMoodEntriesByUser(ctx context.Context, userID int) error {
+	return q.wrapQuery(deleteAllMoodEntriesByUser, func() error {
+		if _, err := q.tx.ExecContext(ctx, deleteMoodEntryTaggingsByUser, userID); err != nil {
+			return err
+		}
+
+		_, err := q.tx.ExecContext(ctx, deleteAllMoodEntriesByUser, userID)
+
+		return err
+	})
+}
+
 type MoodCount struct {
 	Mood  string
 	Count int

--- a/internal/repo/recurrent_expense.go
+++ b/internal/repo/recurrent_expense.go
@@ -287,6 +287,30 @@ func (q *Queries) DeleteRecurrentExpense(ctx context.Context, id, userID int) (i
 	return i, err
 }
 
+const countRecurrentExpensesByUser = `SELECT COUNT(*) FROM "recurrent_expenses" WHERE "user_id" = ?`
+
+func (q *Queries) CountRecurrentExpensesByUser(ctx context.Context, userID int) (int, error) {
+	var c int
+
+	err := q.wrapQuery(countRecurrentExpensesByUser, func() error {
+		row := q.db.QueryRowContext(ctx, countRecurrentExpensesByUser, userID)
+
+		return row.Scan(&c)
+	})
+
+	return c, err
+}
+
+const deleteAllRecurrentExpensesByUser = `DELETE FROM "recurrent_expenses" WHERE "user_id" = ?`
+
+func (q *TxQueries) DeleteAllRecurrentExpensesByUser(ctx context.Context, userID int) error {
+	return q.wrapQuery(deleteAllRecurrentExpensesByUser, func() error {
+		_, err := q.tx.ExecContext(ctx, deleteAllRecurrentExpensesByUser, userID)
+
+		return err
+	})
+}
+
 const selectRecurrentExpense = `
 SELECT * FROM "recurrent_expenses" WHERE "id" = ? AND "user_id" = ? LIMIT 1
 `

--- a/internal/repo/tag.go
+++ b/internal/repo/tag.go
@@ -173,6 +173,32 @@ func (q *Queries) DeleteTag(ctx context.Context, id, userID int) (int, error) {
 	return i, err
 }
 
+const countTagsByUser = `SELECT COUNT(*) FROM "tags" WHERE "user_id" = ?`
+
+func (q *Queries) CountTagsByUser(ctx context.Context, userID int) (int, error) {
+	var c int
+
+	err := q.wrapQuery(countTagsByUser, func() error {
+		row := q.db.QueryRowContext(ctx, countTagsByUser, userID)
+
+		return row.Scan(&c)
+	})
+
+	return c, err
+}
+
+// DeleteAllTagsByUser removes every tag owned by the user. The taggings rows
+// referencing those tags cascade automatically via the tag_id foreign key.
+const deleteAllTagsByUser = `DELETE FROM "tags" WHERE "user_id" = ?`
+
+func (q *TxQueries) DeleteAllTagsByUser(ctx context.Context, userID int) error {
+	return q.wrapQuery(deleteAllTagsByUser, func() error {
+		_, err := q.tx.ExecContext(ctx, deleteAllTagsByUser, userID)
+
+		return err
+	})
+}
+
 func validTagFields() []string {
 	return []string{
 		"id",

--- a/internal/repo/tagging.go
+++ b/internal/repo/tagging.go
@@ -78,6 +78,23 @@ func (q *TxQueries) DeleteTaggingsByTarget(ctx context.Context, taggableType str
 	})
 }
 
+const countTaggingsByTarget = `
+SELECT COUNT(*) FROM "taggings"
+WHERE "taggable_type" = ?
+  AND "taggable_id" = ?`
+
+func (q *Queries) CountTaggingsByTarget(ctx context.Context, taggableType string, taggableID int) (int, error) {
+	var c int
+
+	err := q.wrapQuery(countTaggingsByTarget, func() error {
+		row := q.db.QueryRowContext(ctx, countTaggingsByTarget, taggableType, taggableID)
+
+		return row.Scan(&c)
+	})
+
+	return c, err
+}
+
 const selectTagsForTaggableBase = `
 SELECT t.*
 FROM "taggings" tg

--- a/internal/serve/routes.go
+++ b/internal/serve/routes.go
@@ -21,6 +21,18 @@ func (s *Server) setUpRoutes() {
 
 		root.Get("/dashboard", s.handlers.GetDashboard)
 
+		root.Route("/account", func(account chi.Router) {
+			account.Get("/", s.handlers.GetAccount)
+			account.Post("/expenses/delete-all", s.handlers.PostAccountDeleteExpenses)
+			account.Post("/recurrent-expenses/delete-all", s.handlers.PostAccountDeleteRecurrentExpenses)
+			account.Post("/macro-entries/delete-all", s.handlers.PostAccountDeleteMacroEntries)
+			account.Post("/macro-goals/delete-all", s.handlers.PostAccountDeleteMacroGoals)
+			account.Post("/foods/delete-all", s.handlers.PostAccountDeleteFoods)
+			account.Post("/moods/delete-all", s.handlers.PostAccountDeleteMoodEntries)
+			account.Post("/tags/delete-all", s.handlers.PostAccountDeleteTags)
+			account.Post("/delete-all", s.handlers.PostAccountDeleteAll)
+		})
+
 		root.Route("/exports", func(exports chi.Router) {
 			exports.Get("/", s.handlers.GetExports)
 			exports.Get("/expenses.json", s.handlers.GetExportsExpenses)

--- a/web/views/account/index.html
+++ b/web/views/account/index.html
@@ -1,0 +1,143 @@
+{{ template "layout" . }}
+{{ define "main" }}
+  <section class="card" aria-labelledby="account-card-title">
+    <header class="card-header">
+      <h1 id="account-card-title" class="card-title">Account</h1>
+    </header>
+    <p class="card-empty">
+      Permanently delete your data. Each action removes every record of that
+      type for your account and cannot be undone.
+    </p>
+  </section>
+
+  <div class="card-grid">
+    <section class="card" aria-labelledby="account-expenses-title">
+      <header class="card-header">
+        <h2 id="account-expenses-title" class="card-title">Expenses</h2>
+      </header>
+      <span class="card-delta">{{ .counts.Expenses }} record(s)</span>
+      <form
+        action="/account/expenses/delete-all"
+        method="post"
+        data-turbo-confirm="Delete ALL your expenses? This cannot be undone."
+      >
+        {{ template "csrf" . }}
+        {{ template "delete_button" . }}
+      </form>
+    </section>
+
+    <section class="card" aria-labelledby="account-recurrent-expenses-title">
+      <header class="card-header">
+        <h2 id="account-recurrent-expenses-title" class="card-title">
+          Recurrent Expenses
+        </h2>
+      </header>
+      <span class="card-delta">{{ .counts.RecurrentExpenses }} record(s)</span>
+      <form
+        action="/account/recurrent-expenses/delete-all"
+        method="post"
+        data-turbo-confirm="Delete ALL your recurrent expenses? This cannot be undone."
+      >
+        {{ template "csrf" . }}
+        {{ template "delete_button" . }}
+      </form>
+    </section>
+
+    <section class="card" aria-labelledby="account-macro-entries-title">
+      <header class="card-header">
+        <h2 id="account-macro-entries-title" class="card-title">
+          Macro Entries
+        </h2>
+      </header>
+      <span class="card-delta">{{ .counts.MacroEntries }} record(s)</span>
+      <form
+        action="/account/macro-entries/delete-all"
+        method="post"
+        data-turbo-confirm="Delete ALL your macro entries? This cannot be undone."
+      >
+        {{ template "csrf" . }}
+        {{ template "delete_button" . }}
+      </form>
+    </section>
+
+    <section class="card" aria-labelledby="account-macro-goals-title">
+      <header class="card-header">
+        <h2 id="account-macro-goals-title" class="card-title">Macro Goals</h2>
+      </header>
+      <span class="card-delta">{{ .counts.MacroGoals }} record(s)</span>
+      <form
+        action="/account/macro-goals/delete-all"
+        method="post"
+        data-turbo-confirm="Delete your macro goals? This cannot be undone."
+      >
+        {{ template "csrf" . }}
+        {{ template "delete_button" . }}
+      </form>
+    </section>
+
+    <section class="card" aria-labelledby="account-foods-title">
+      <header class="card-header">
+        <h2 id="account-foods-title" class="card-title">Foods</h2>
+      </header>
+      <span class="card-delta">{{ .counts.Foods }} record(s)</span>
+      <form
+        action="/account/foods/delete-all"
+        method="post"
+        data-turbo-confirm="Delete ALL your foods? This cannot be undone."
+      >
+        {{ template "csrf" . }}
+        {{ template "delete_button" . }}
+      </form>
+    </section>
+
+    <section class="card" aria-labelledby="account-moods-title">
+      <header class="card-header">
+        <h2 id="account-moods-title" class="card-title">Moods</h2>
+      </header>
+      <span class="card-delta">{{ .counts.MoodEntries }} record(s)</span>
+      <form
+        action="/account/moods/delete-all"
+        method="post"
+        data-turbo-confirm="Delete ALL your mood entries? This cannot be undone."
+      >
+        {{ template "csrf" . }}
+        {{ template "delete_button" . }}
+      </form>
+    </section>
+
+    <section class="card" aria-labelledby="account-tags-title">
+      <header class="card-header">
+        <h2 id="account-tags-title" class="card-title">Tags</h2>
+      </header>
+      <span class="card-delta">{{ .counts.Tags }} record(s)</span>
+      <form
+        action="/account/tags/delete-all"
+        method="post"
+        data-turbo-confirm="Delete ALL your tags? This cannot be undone."
+      >
+        {{ template "csrf" . }}
+        {{ template "delete_button" . }}
+      </form>
+    </section>
+  </div>
+
+  <section class="card" aria-labelledby="account-delete-all-title">
+    <header class="card-header">
+      <h2 id="account-delete-all-title" class="card-title">
+        Delete everything
+      </h2>
+    </header>
+    <p class="card-empty">
+      This removes every record across all sections above in one action. This
+      cannot be undone.
+    </p>
+    <form
+      action="/account/delete-all"
+      method="post"
+      data-turbo-confirm="Delete ALL of your data across every section? This CANNOT be undone."
+    >
+      {{ template "csrf" . }}
+      {{ template "delete_button" . }}
+    </form>
+  </section>
+{{ end }}

--- a/web/views/common/_header.html
+++ b/web/views/common/_header.html
@@ -26,6 +26,7 @@
           <li><a href="/exports">Exports</a></li>
           <li><a href="/moods">Moods</a></li>
           <li class="site-nav-divider"></li>
+          <li><a href="/account">Account</a></li>
           <li>
             <form action="/logout" method="post" class="site-nav-logout">
               {{ template "csrf" . }}


### PR DESCRIPTION
## What & why

Adds a new **`/account`** "danger zone" so a user can delete all of their own records per model type, each in its own card with a **browser confirmation** prompt, plus a master **"Delete everything"** action. Previously the app only supported deleting records one at a time.

## Scope of data types

Expenses, recurrent expenses, macro entries, macro goals, foods, mood entries, and tags — all user-scoped tables. (`categories` is a global lookup and is excluded.)

## Implementation

- **repo** (`internal/repo/*.go`): `DeleteAll<Model>ByUser` transaction methods and `Count<Model>ByUser` reads per model. Expense/mood bulk deletes also purge their polymorphic `taggings` (which don't cascade); deleting tags cascades taggings via the `tag_id` FK.
- **logic**: per-model `DeleteAll<Model>` wrappers, plus `logic_account.go` with an atomic `DeleteAllUserData` (single transaction, tags deleted last) and `FindAccountDataCounts`.
- **handlers/routes**: `handle_account.go` with `GetAccount`, per-model delete handlers, and `PostAccountDeleteAll`; new `/account` route group and header nav link.
- **view**: `web/views/account/index.html` using the existing `data-turbo-confirm` pattern and shared `csrf`/`delete_button` partials.

## Testing

- **Full HTTP-stack tests** (`handle_account_test.go`) drive routing → auth gate → CSRF → template render → bulk delete: page renders with correct counts, unauthenticated users redirect to login, per-model and global deletes work, and another user's data stays intact.
- **Logic tests** (`logic_account_test.go`) cover per-model deletes, orphaned-taggings cleanup, tag/tagging cascade behavior, the global wipe, and cross-user ownership isolation.
- `make test` passes; `make lint-fix` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)