### PR TITLE
Add quick-expense entry with per-user category memory

### DIFF
--- a/internal/db/migrations/20260718000100_create_expense_category_mappings.sql
+++ b/internal/db/migrations/20260718000100_create_expense_category_mappings.sql
@@ -1,0 +1,19 @@
+-- +goose Up
+CREATE TABLE IF NOT EXISTS "expense_category_mappings" (
+  "id" INTEGER PRIMARY KEY NOT NULL,
+	"user_id" INTEGER NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+	"category_id" INTEGER NOT NULL REFERENCES "categories"("id") ON DELETE CASCADE,
+	"description_key" TEXT NOT NULL,
+  "created_at" INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+  "updated_at" INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+);
+
+CREATE UNIQUE INDEX "idx_expense_category_mappings_user_desc"
+  ON "expense_category_mappings" ("user_id", "description_key");
+
+PRAGMA user_version = 25;
+
+-- +goose Down
+DROP TABLE IF EXISTS "expense_category_mappings";
+
+PRAGMA user_version = 24;

--- a/internal/handlers/handle_expenses.go
+++ b/internal/handlers/handle_expenses.go
@@ -166,6 +166,7 @@ func (h *Handler) GetExpensesNew(w http.ResponseWriter, r *http.Request) {
 	}
 
 	setExpenseFormData(data, categories, repo.Expense{}, "")
+	setQuickFormData(data, categories, "", false)
 
 	h.render(w, http.StatusOK, ExpensesNew, data)
 }
@@ -198,6 +199,7 @@ func (h *Handler) PostExpenses(w http.ResponseWriter, r *http.Request) {
 
 	categories, _, categoriesErr := h.findCategories(ctx)
 	setExpenseFormData(data, categories, repo.Expense{}, rawTagsInput)
+	setQuickFormData(data, categories, "", false)
 
 	params, err := parseExpenseForm(r)
 	if err != nil {

--- a/internal/handlers/handle_quick_expense.go
+++ b/internal/handlers/handle_quick_expense.go
@@ -1,0 +1,104 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/ad9311/ninete/internal/logic"
+	"github.com/ad9311/ninete/internal/prog"
+	"github.com/ad9311/ninete/internal/repo"
+)
+
+// PostExpensesQuick handles the quick-add expense form: a single free-text field
+// ("description, amount, date"). It resolves the category from a remembered
+// mapping; on the first use of a description it re-renders the form asking the
+// user to pick a category, which is then saved for future reuse.
+func (h *Handler) PostExpensesQuick(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	data := h.tmplData(r)
+	user := getCurrentUser(r)
+
+	if err := r.ParseForm(); err != nil {
+		h.renderQuickErr(w, r, "", err)
+
+		return
+	}
+
+	rawInput := r.FormValue("quick_input")
+	categories, _, categoriesErr := h.findCategories(ctx)
+	setExpenseFormData(data, categories, repo.Expense{}, "")
+	setQuickFormData(data, categories, rawInput, false)
+
+	parsed, err := logic.ParseQuickExpense(rawInput, parseTZOffset(r))
+	if err != nil {
+		h.renderQuickErr(w, r, rawInput, err)
+
+		return
+	}
+
+	categoryID, err := parseOptionalCategoryID(r)
+	if err != nil {
+		h.renderQuickErr(w, r, rawInput, err)
+
+		return
+	}
+
+	if categoryID == 0 {
+		resolvedID, found, resolveErr := h.store.ResolveQuickExpenseCategory(ctx, user.ID, parsed.Description)
+		if resolveErr != nil {
+			h.renderQuickErr(w, r, rawInput, resolveErr)
+
+			return
+		}
+		if !found {
+			setQuickFormData(data, categories, rawInput, true)
+			// Turbo only renders a form response on non-2xx; 422 signals "re-render".
+			h.render(w, http.StatusUnprocessableEntity, ExpensesNew, data)
+
+			return
+		}
+		categoryID = resolvedID
+	}
+
+	if _, err := h.store.CreateQuickExpense(ctx, user.ID, categoryID, parsed); err != nil {
+		h.renderQuickErr(w, r, rawInput, err)
+
+		return
+	}
+
+	if categoriesErr != nil {
+		h.app.Logger.Errorf("failed to load categories: %v", categoriesErr)
+	}
+
+	http.Redirect(w, r, "/expenses", http.StatusSeeOther)
+}
+
+// renderQuickErr re-renders the new-expense page with the quick form active,
+// preserving the raw input and showing the error message.
+func (h *Handler) renderQuickErr(w http.ResponseWriter, r *http.Request, rawInput string, err error) {
+	data := h.tmplData(r)
+	categories, _, _ := h.findCategories(r.Context())
+	setExpenseFormData(data, categories, repo.Expense{}, "")
+	setQuickFormData(data, categories, rawInput, false)
+	h.renderErr(w, r, http.StatusBadRequest, ExpensesNew, err)
+}
+
+func parseOptionalCategoryID(r *http.Request) (int, error) {
+	raw := r.FormValue("category_id")
+	if raw == "" {
+		return 0, nil
+	}
+
+	return prog.ParseID(raw, "Category ID")
+}
+
+func setQuickFormData(
+	data map[string]any,
+	categories []repo.Category,
+	quickInput string,
+	quickNeedsCategory bool,
+) {
+	data["categories"] = categories
+	data["quickInput"] = quickInput
+	data["quickNeedsCategory"] = quickNeedsCategory
+	data["quickActive"] = quickInput != "" || quickNeedsCategory
+}

--- a/internal/handlers/handle_quick_expense_test.go
+++ b/internal/handlers/handle_quick_expense_test.go
@@ -1,0 +1,105 @@
+package handlers_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ad9311/ninete/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostExpensesQuick(t *testing.T) {
+	s := spec.New(t)
+	handler := s.WrappedHandler()
+
+	cases := []struct {
+		name string
+		fn   func(*testing.T)
+	}{
+		{
+			name: "should_ask_for_category_on_first_use",
+			fn: func(t *testing.T) {
+				s.CreateAuthUser(t, "quick_h_1", "quick_h_1@example.com", "quick_password_1")
+				s.CreateCategory(t, "quick_h_cat_1")
+				cookies := s.AuthCookies(t, "quick_h_1@example.com", "quick_password_1")
+				csrfToken, cookies := s.CSRFFrom(t, "/expenses/new", cookies)
+
+				form := url.Values{"quick_input": {"Netflix, 15.99, today"}}
+				req := spec.NewPostRequest("/expenses/quick", form.Encode(), cookies, csrfToken)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				require.Equal(t, http.StatusUnprocessableEntity, rec.Code)
+				require.Contains(t, rec.Body.String(), "Select a category")
+			},
+		},
+		{
+			name: "should_create_and_redirect_when_category_provided",
+			fn: func(t *testing.T) {
+				s.CreateAuthUser(t, "quick_h_2", "quick_h_2@example.com", "quick_password_2")
+				category := s.CreateCategory(t, "quick_h_cat_2")
+				cookies := s.AuthCookies(t, "quick_h_2@example.com", "quick_password_2")
+				csrfToken, cookies := s.CSRFFrom(t, "/expenses/new", cookies)
+
+				form := url.Values{
+					"quick_input": {"Spotify, 9.99, today"},
+					"category_id": {fmt.Sprintf("%d", category.ID)},
+				}
+				req := spec.NewPostRequest("/expenses/quick", form.Encode(), cookies, csrfToken)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				require.Equal(t, http.StatusSeeOther, rec.Code)
+				require.Equal(t, "/expenses", rec.Header().Get("Location"))
+			},
+		},
+		{
+			name: "should_reuse_remembered_category_without_asking",
+			fn: func(t *testing.T) {
+				s.CreateAuthUser(t, "quick_h_3", "quick_h_3@example.com", "quick_password_3")
+				category := s.CreateCategory(t, "quick_h_cat_3")
+				cookies := s.AuthCookies(t, "quick_h_3@example.com", "quick_password_3")
+				csrfToken, cookies := s.CSRFFrom(t, "/expenses/new", cookies)
+
+				first := url.Values{
+					"quick_input": {"Rent, 1200, today"},
+					"category_id": {fmt.Sprintf("%d", category.ID)},
+				}
+				req := spec.NewPostRequest("/expenses/quick", first.Encode(), cookies, csrfToken)
+				handler.ServeHTTP(httptest.NewRecorder(), req)
+
+				second := url.Values{"quick_input": {"Rent, 1300, today"}}
+				req = spec.NewPostRequest("/expenses/quick", second.Encode(), cookies, csrfToken)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				require.Equal(t, http.StatusSeeOther, rec.Code)
+				require.Equal(t, "/expenses", rec.Header().Get("Location"))
+			},
+		},
+		{
+			name: "should_return_bad_request_on_malformed_input",
+			fn: func(t *testing.T) {
+				s.CreateAuthUser(t, "quick_h_4", "quick_h_4@example.com", "quick_password_4")
+				cookies := s.AuthCookies(t, "quick_h_4@example.com", "quick_password_4")
+				csrfToken, cookies := s.CSRFFrom(t, "/expenses/new", cookies)
+
+				form := url.Values{"quick_input": {"missing amount and date"}}
+				req := spec.NewPostRequest("/expenses/quick", form.Encode(), cookies, csrfToken)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+
+				require.Equal(t, http.StatusBadRequest, rec.Code)
+				require.True(t, strings.Contains(rec.Body.String(), "description, amount, date"))
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, tc.fn)
+	}
+}

--- a/internal/logic/errs.go
+++ b/internal/logic/errs.go
@@ -16,4 +16,8 @@ var (
 	ErrTagResolutionFailed = errors.New("failed to resolve tags")
 
 	ErrInvalidMood = errors.New("invalid mood selection")
+
+	ErrQuickExpenseFormat = errors.New("quick expense must be: description, amount, date")
+	ErrQuickExpenseAmount = errors.New("invalid amount")
+	ErrQuickExpenseDate   = errors.New("invalid date")
 )

--- a/internal/logic/logic_quick_expense.go
+++ b/internal/logic/logic_quick_expense.go
@@ -1,0 +1,185 @@
+package logic
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ad9311/ninete/internal/repo"
+)
+
+// quickDateLayouts are attempted in order when parsing an explicit date.
+var quickDateLayouts = []string{ //nolint:gochecknoglobals // static lookup table
+	"2 January 2006",
+	"2 Jan 2006",
+	"January 2 2006",
+	"Jan 2 2006",
+	"2006-01-02",
+	"02/01/2006",
+	"02-01-2006",
+}
+
+// QuickExpenseParsed holds the fields extracted from a quick-add input string.
+type QuickExpenseParsed struct {
+	Description string
+	Amount      uint64
+	Date        int64
+}
+
+// ParseQuickExpense parses a "description, amount, date" input into structured
+// fields. tzOffsetMinutes is the client's Date.getTimezoneOffset() value, used
+// to resolve relative dates ("today"/"yesterday") to the client's calendar day.
+func ParseQuickExpense(raw string, tzOffsetMinutes int) (QuickExpenseParsed, error) {
+	var parsed QuickExpenseParsed
+
+	parts := strings.Split(raw, ",")
+	if len(parts) != 3 {
+		return parsed, ErrQuickExpenseFormat
+	}
+
+	description := strings.TrimSpace(parts[0])
+
+	amount, err := parseDollarsToCents(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return parsed, err
+	}
+
+	date, err := parseQuickDate(strings.TrimSpace(parts[2]), tzOffsetMinutes)
+	if err != nil {
+		return parsed, err
+	}
+
+	parsed.Description = description
+	parsed.Amount = amount
+	parsed.Date = date
+
+	return parsed, nil
+}
+
+func parseDollarsToCents(s string) (uint64, error) {
+	normalized := strings.ReplaceAll(s, ",", "")
+	if normalized == "" {
+		return 0, ErrQuickExpenseAmount
+	}
+
+	dollars, err := strconv.ParseFloat(normalized, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: %w", ErrQuickExpenseAmount, err)
+	}
+	if dollars < 0 || math.IsInf(dollars, 0) || math.IsNaN(dollars) {
+		return 0, ErrQuickExpenseAmount
+	}
+
+	return uint64(math.Round(dollars * 100)), nil
+}
+
+func parseQuickDate(s string, tzOffsetMinutes int) (int64, error) {
+	loc := time.FixedZone("client", -tzOffsetMinutes*60)
+	now := time.Now().In(loc)
+	year, month, day := now.Date()
+	today := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+
+	switch strings.ToLower(s) {
+	case "today":
+		return today.Unix(), nil
+	case "yesterday":
+		return today.AddDate(0, 0, -1).Unix(), nil
+	}
+
+	titled := titleCaseWords(s)
+	for _, layout := range quickDateLayouts {
+		if t, err := time.Parse(layout, titled); err == nil {
+			return t.Unix(), nil
+		}
+	}
+
+	return 0, ErrQuickExpenseDate
+}
+
+// titleCaseWords upper-cases the first rune of each whitespace-separated word so
+// month names like "june" match Go's "January" reference layout.
+func titleCaseWords(s string) string {
+	fields := strings.Fields(s)
+	for i, field := range fields {
+		runes := []rune(strings.ToLower(field))
+		runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+		fields[i] = string(runes)
+	}
+
+	return strings.Join(fields, " ")
+}
+
+// ResolveQuickExpenseCategory looks up the remembered category for a user's
+// description. The bool return is false when no mapping exists yet.
+func (s *Store) ResolveQuickExpenseCategory(
+	ctx context.Context,
+	userID int,
+	description string,
+) (int, bool, error) {
+	mapping, found, err := s.queries.SelectExpenseCategoryMapping(ctx, userID, descriptionKey(description))
+	if err != nil {
+		return 0, false, err
+	}
+	if !found {
+		return 0, false, nil
+	}
+
+	return mapping.CategoryID, true, nil
+}
+
+// CreateQuickExpense creates an expense from parsed quick-add fields and, in the
+// same transaction, remembers the description-to-category mapping for reuse.
+func (s *Store) CreateQuickExpense(
+	ctx context.Context,
+	userID, categoryID int,
+	parsed QuickExpenseParsed,
+) (repo.Expense, error) {
+	var expense repo.Expense
+
+	params := ExpenseParams{
+		ExpenseBaseParams: ExpenseBaseParams{
+			CategoryID:  categoryID,
+			Description: parsed.Description,
+			Amount:      parsed.Amount,
+		},
+		Date: parsed.Date,
+	}
+	if err := s.ValidateStruct(params); err != nil {
+		return expense, err
+	}
+
+	err := s.queries.WithTx(ctx, func(tq *repo.TxQueries) error {
+		var txErr error
+
+		expense, txErr = tq.InsertExpense(ctx, repo.InsertExpenseParams{
+			UserID:      userID,
+			CategoryID:  params.CategoryID,
+			Description: params.Description,
+			Amount:      params.Amount,
+			Date:        params.Date,
+		})
+		if txErr != nil {
+			return txErr
+		}
+
+		_, txErr = tq.UpsertExpenseCategoryMapping(ctx, repo.UpsertExpenseCategoryMappingParams{
+			UserID:         userID,
+			CategoryID:     categoryID,
+			DescriptionKey: descriptionKey(parsed.Description),
+		})
+
+		return txErr
+	})
+	if err != nil {
+		return expense, err
+	}
+
+	return expense, nil
+}
+
+func descriptionKey(description string) string {
+	return strings.ToLower(strings.TrimSpace(description))
+}

--- a/internal/logic/logic_quick_expense_test.go
+++ b/internal/logic/logic_quick_expense_test.go
@@ -1,0 +1,179 @@
+package logic_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ad9311/ninete/internal/logic"
+	"github.com/ad9311/ninete/internal/repo"
+	"github.com/ad9311/ninete/internal/spec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseQuickExpense(t *testing.T) {
+	utcMidnightToday := func() int64 {
+		y, m, d := time.Now().UTC().Date()
+
+		return time.Date(y, m, d, 0, 0, 0, 0, time.UTC).Unix()
+	}
+
+	cases := []struct {
+		name string
+		fn   func(*testing.T)
+	}{
+		{
+			name: "should_parse_decimal_amount_and_today",
+			fn: func(t *testing.T) {
+				parsed, err := logic.ParseQuickExpense("Uber, 3344.22, today", 0)
+				require.NoError(t, err)
+				require.Equal(t, "Uber", parsed.Description)
+				require.Equal(t, uint64(334422), parsed.Amount)
+				require.Equal(t, utcMidnightToday(), parsed.Date)
+			},
+		},
+		{
+			name: "should_parse_integer_amount_as_whole_dollars",
+			fn: func(t *testing.T) {
+				parsed, err := logic.ParseQuickExpense("Rent, 23044, today", 0)
+				require.NoError(t, err)
+				require.Equal(t, uint64(2304400), parsed.Amount)
+			},
+		},
+		{
+			name: "should_parse_small_decimal_amount",
+			fn: func(t *testing.T) {
+				parsed, err := logic.ParseQuickExpense("Coffee, 33.33, today", 0)
+				require.NoError(t, err)
+				require.Equal(t, uint64(3333), parsed.Amount)
+			},
+		},
+		{
+			name: "should_parse_yesterday",
+			fn: func(t *testing.T) {
+				parsed, err := logic.ParseQuickExpense("Uber, 10, yesterday", 0)
+				require.NoError(t, err)
+				require.Equal(t, utcMidnightToday()-int64((time.Hour*24).Seconds()), parsed.Date)
+			},
+		},
+		{
+			name: "should_parse_explicit_lowercase_month_date",
+			fn: func(t *testing.T) {
+				parsed, err := logic.ParseQuickExpense("Uber, 10, 12 june 2026", 0)
+				require.NoError(t, err)
+				expected := time.Date(2026, time.June, 12, 0, 0, 0, 0, time.UTC).Unix()
+				require.Equal(t, expected, parsed.Date)
+			},
+		},
+		{
+			name: "should_parse_iso_date",
+			fn: func(t *testing.T) {
+				parsed, err := logic.ParseQuickExpense("Uber, 10, 2026-06-12", 0)
+				require.NoError(t, err)
+				expected := time.Date(2026, time.June, 12, 0, 0, 0, 0, time.UTC).Unix()
+				require.Equal(t, expected, parsed.Date)
+			},
+		},
+		{
+			name: "should_fail_on_wrong_field_count",
+			fn: func(t *testing.T) {
+				_, err := logic.ParseQuickExpense("Uber, 10", 0)
+				require.ErrorIs(t, err, logic.ErrQuickExpenseFormat)
+			},
+		},
+		{
+			name: "should_fail_on_invalid_amount",
+			fn: func(t *testing.T) {
+				_, err := logic.ParseQuickExpense("Uber, abc, today", 0)
+				require.ErrorIs(t, err, logic.ErrQuickExpenseAmount)
+			},
+		},
+		{
+			name: "should_fail_on_invalid_date",
+			fn: func(t *testing.T) {
+				_, err := logic.ParseQuickExpense("Uber, 10, someday", 0)
+				require.ErrorIs(t, err, logic.ErrQuickExpenseDate)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, tc.fn)
+	}
+}
+
+func TestQuickExpenseCategoryMapping(t *testing.T) {
+	s := spec.New(t)
+	ctx := t.Context()
+	user := s.CreateUser(t, repo.InsertUserParams{
+		Username:     "quick_user_1",
+		Email:        "quick_user_1@example.com",
+		PasswordHash: []byte("quick_user_hash_1"),
+	})
+	category := s.CreateCategory(t, "quick category 1")
+	other := s.CreateCategory(t, "quick category 2")
+
+	cases := []struct {
+		name string
+		fn   func(*testing.T)
+	}{
+		{
+			name: "should_report_no_mapping_before_first_use",
+			fn: func(t *testing.T) {
+				_, found, err := s.Store.ResolveQuickExpenseCategory(ctx, user.ID, "Netflix")
+				require.NoError(t, err)
+				require.False(t, found)
+			},
+		},
+		{
+			name: "should_create_expense_and_remember_category",
+			fn: func(t *testing.T) {
+				parsed := logic.QuickExpenseParsed{
+					Description: "Netflix",
+					Amount:      1599,
+					Date:        1735689600,
+				}
+				expense, err := s.Store.CreateQuickExpense(ctx, user.ID, category.ID, parsed)
+				require.NoError(t, err)
+				require.Positive(t, expense.ID)
+				require.Equal(t, category.ID, expense.CategoryID)
+
+				id, found, err := s.Store.ResolveQuickExpenseCategory(ctx, user.ID, "netflix")
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, category.ID, id)
+			},
+		},
+		{
+			name: "should_overwrite_remembered_category_on_reuse",
+			fn: func(t *testing.T) {
+				parsed := logic.QuickExpenseParsed{
+					Description: "Spotify",
+					Amount:      999,
+					Date:        1735689600,
+				}
+				_, err := s.Store.CreateQuickExpense(ctx, user.ID, category.ID, parsed)
+				require.NoError(t, err)
+
+				_, err = s.Store.CreateQuickExpense(ctx, user.ID, other.ID, parsed)
+				require.NoError(t, err)
+
+				id, found, err := s.Store.ResolveQuickExpenseCategory(ctx, user.ID, "Spotify")
+				require.NoError(t, err)
+				require.True(t, found)
+				require.Equal(t, other.ID, id)
+			},
+		},
+		{
+			name: "should_fail_validation_for_short_description",
+			fn: func(t *testing.T) {
+				parsed := logic.QuickExpenseParsed{Description: "no", Amount: 100, Date: 1735689600}
+				_, err := s.Store.CreateQuickExpense(ctx, user.ID, category.ID, parsed)
+				require.ErrorIs(t, err, logic.ErrValidationFailed)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, tc.fn)
+	}
+}

--- a/internal/repo/expense_category_mapping.go
+++ b/internal/repo/expense_category_mapping.go
@@ -1,0 +1,93 @@
+package repo
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+)
+
+type ExpenseCategoryMapping struct {
+	ID             int
+	UserID         int
+	CategoryID     int
+	DescriptionKey string
+	CreatedAt      int64
+	UpdatedAt      int64
+}
+
+type UpsertExpenseCategoryMappingParams struct {
+	UserID         int
+	CategoryID     int
+	DescriptionKey string
+}
+
+const selectExpenseCategoryMapping = `
+SELECT * FROM "expense_category_mappings"
+WHERE "user_id" = ? AND "description_key" = ?`
+
+// SelectExpenseCategoryMapping returns the mapping for a user's description key.
+// The second return value is false when no mapping exists.
+func (q *Queries) SelectExpenseCategoryMapping(
+	ctx context.Context,
+	userID int,
+	descriptionKey string,
+) (ExpenseCategoryMapping, bool, error) {
+	var m ExpenseCategoryMapping
+
+	err := q.wrapQuery(selectExpenseCategoryMapping, func() error {
+		row := q.db.QueryRowContext(ctx, selectExpenseCategoryMapping, userID, descriptionKey)
+
+		return row.Scan(
+			&m.ID,
+			&m.UserID,
+			&m.CategoryID,
+			&m.DescriptionKey,
+			&m.CreatedAt,
+			&m.UpdatedAt,
+		)
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return m, false, nil
+	}
+	if err != nil {
+		return m, false, err
+	}
+
+	return m, true, nil
+}
+
+const upsertExpenseCategoryMapping = `
+INSERT INTO "expense_category_mappings" ("user_id", "category_id", "description_key")
+VALUES (?, ?, ?)
+ON CONFLICT ("user_id", "description_key")
+DO UPDATE SET "category_id" = excluded."category_id", "updated_at" = ?
+RETURNING *`
+
+func (q *TxQueries) UpsertExpenseCategoryMapping(
+	ctx context.Context,
+	params UpsertExpenseCategoryMappingParams,
+) (ExpenseCategoryMapping, error) {
+	var m ExpenseCategoryMapping
+
+	err := q.wrapQuery(upsertExpenseCategoryMapping, func() error {
+		row := q.tx.QueryRowContext(
+			ctx,
+			upsertExpenseCategoryMapping,
+			params.UserID,
+			params.CategoryID,
+			params.DescriptionKey,
+			newUpdatedAt(),
+		)
+
+		return row.Scan(
+			&m.ID,
+			&m.UserID,
+			&m.CategoryID,
+			&m.DescriptionKey,
+			&m.CreatedAt,
+			&m.UpdatedAt,
+		)
+	})
+
+	return m, err
+}

--- a/internal/serve/routes.go
+++ b/internal/serve/routes.go
@@ -41,6 +41,7 @@ func (s *Server) setUpRoutes() {
 		root.Route("/expenses", func(expenses chi.Router) {
 			expenses.Get("/", s.handlers.GetExpenses)
 			expenses.Post("/", s.handlers.PostExpenses)
+			expenses.Post("/quick", s.handlers.PostExpensesQuick)
 			expenses.Get("/new", s.handlers.GetExpensesNew)
 			expenses.Get("/stats", s.handlers.GetExpensesStats)
 			expenses.Route("/{id}", func(expenses chi.Router) {

--- a/web/static/css/layout.css
+++ b/web/static/css/layout.css
@@ -565,6 +565,23 @@ button:focus-visible {
   background: var(--color-neutral-hover);
 }
 
+.quick-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-1);
+  font-weight: 500;
+  color: var(--color-text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.quick-hint {
+  margin: calc(-1 * var(--space-2)) 0 var(--space-2);
+  font-size: var(--font-size-1);
+  color: var(--color-text-muted);
+}
+
 .site-nav-caret {
   font-size: 0.7em;
   line-height: 1;

--- a/web/static/js/controllers/quickExpenseController.ts
+++ b/web/static/js/controllers/quickExpenseController.ts
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus";
+
+const STORAGE_KEY = "expense-quick-mode";
+
+export default class extends Controller {
+  static targets = ["regular", "quick", "switch"];
+
+  declare readonly regularTarget: HTMLElement;
+  declare readonly quickTarget: HTMLElement;
+  declare readonly switchTarget: HTMLInputElement;
+
+  connect() {
+    const force = this.element.getAttribute("data-quick-force") === "1";
+    const on = force || this.stored();
+    this.switchTarget.checked = on;
+    this.apply(on);
+  }
+
+  toggle() {
+    const on = this.switchTarget.checked;
+    localStorage.setItem(STORAGE_KEY, on ? "1" : "0");
+    this.apply(on);
+  }
+
+  private stored(): boolean {
+    return localStorage.getItem(STORAGE_KEY) === "1";
+  }
+
+  private apply(on: boolean) {
+    this.regularTarget.hidden = on;
+    this.quickTarget.hidden = !on;
+  }
+}

--- a/web/static/js/index.ts
+++ b/web/static/js/index.ts
@@ -22,6 +22,7 @@ import MacroCalcController from "./controllers/macroCalcController";
 import MacroTrendController from "./controllers/macroTrendController";
 import MoodChartController from "./controllers/moodChartController";
 import ThemeController from "./controllers/themeController";
+import QuickExpenseController from "./controllers/quickExpenseController";
 import { initIcons } from "./icons";
 
 window.Stimulus = Application.start();
@@ -39,5 +40,6 @@ window.Stimulus.register("macro-calc", MacroCalcController);
 window.Stimulus.register("macro-trend", MacroTrendController);
 window.Stimulus.register("mood-chart", MoodChartController);
 window.Stimulus.register("theme", ThemeController);
+window.Stimulus.register("quick-expense", QuickExpenseController);
 
 document.addEventListener("turbo:load", initIcons);

--- a/web/views/expenses/_quick_form.html
+++ b/web/views/expenses/_quick_form.html
@@ -1,0 +1,30 @@
+{{ define "quick_expense_form" }}
+  <form action="/expenses/quick" method="post">
+    {{ template "csrf" . }}
+    <label>
+      Quick add
+      <input
+        type="text"
+        name="quick_input"
+        value="{{ .quickInput }}"
+        placeholder="Description, amount, date"
+      />
+    </label>
+    <p class="quick-hint">Example: Uber, 3344.22, today</p>
+    {{ if .quickNeedsCategory }}
+      <label>
+        Category
+        <select name="category_id">
+          <option value="">Select a category</option>
+          {{ range .categories }}
+            <option value="{{ .ID }}">{{ .Name }}</option>
+          {{ end }}
+        </select>
+      </label>
+      <p class="quick-hint">
+        First time for this description. Pick a category to remember it.
+      </p>
+    {{ end }}
+    {{ template "submit_button" . }}
+  </form>
+{{ end }}

--- a/web/views/expenses/new.html
+++ b/web/views/expenses/new.html
@@ -1,9 +1,22 @@
 {{ template "layout" . }}
 {{ define "main" }}
-  <section class="card" aria-labelledby="new-expense-card-title">
+  <section
+    class="card"
+    aria-labelledby="new-expense-card-title"
+    data-controller="quick-expense"
+    data-quick-force="{{ if .quickActive }}1{{ end }}"
+  >
     <header class="card-header">
       <h1 id="new-expense-card-title" class="card-title">New expense</h1>
       <nav class="card-actions" aria-label="Expense navigation">
+        <label class="quick-toggle" title="Quick add">
+          <input
+            type="checkbox"
+            data-quick-expense-target="switch"
+            data-action="change->quick-expense#toggle"
+          />
+          Quick
+        </label>
         <a
           href="/expenses"
           class="card-action-link"
@@ -23,14 +36,19 @@
       </nav>
     </header>
     {{ template "form_error" . }}
-    <form
-      action="/expenses"
-      method="post"
-      data-controller="date amount"
-      data-action="submit->date#prepare submit->amount#prepare"
-    >
-      {{ template "csrf" . }}
-      {{ template "expense_form" . }}
-    </form>
+    <div data-quick-expense-target="regular">
+      <form
+        action="/expenses"
+        method="post"
+        data-controller="date amount"
+        data-action="submit->date#prepare submit->amount#prepare"
+      >
+        {{ template "csrf" . }}
+        {{ template "expense_form" . }}
+      </form>
+    </div>
+    <div data-quick-expense-target="quick" hidden>
+      {{ template "quick_expense_form" . }}
+    </div>
   </section>
 {{ end }}


### PR DESCRIPTION
## Summary

Adds a quick-add expense mode on `/expenses/new`. Users type a single free-text field `description, amount, date` (e.g. `Uber, 23.44, today`) instead of the full form. The mode is a client-side toggle persisted in `localStorage`, mirroring the theme pattern.

## Behavior

- **Parsing**: comma-separated fields; amounts are dollars stored as cents; dates support `today`/`yesterday` plus explicit formats (e.g. `12 june 2026`), resolved against the client tz offset.
- **Category memory**: remembers the description→category choice per user via a new `expense_category_mappings` table (unique on `user_id, description_key`). First use of a description prompts for a category; reuse auto-resolves silently.
- **Endpoint**: `POST /expenses/quick`. Returns `422` to re-render the form when a category is needed (Turbo requires a non-2xx to render a form response).

## Notes

- No mapping-edit UI yet (deferred to v2). Remembered mappings are editable directly in the `expense_category_mappings` table; deleting a row re-prompts on next quick-add.
- Migration bumps `PRAGMA user_version` 24→25.

## Testing

- `make lint-fix` — clean
- `make test` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)