### PR TITLE
feat: add Content-Security-Policy and security headers

### DIFF
--- a/internal/handlers/constants.go
+++ b/internal/handlers/constants.go
@@ -6,6 +6,7 @@ type ContextKey string
 const (
 	KeyCurrentUser      = ContextKey("userID")
 	KeyTemplateData     = ContextKey("templateData")
+	KeyCSPNonce         = ContextKey("cspNonce")
 	KeyExpense          = ContextKey("expenseID")
 	KeyRecurrentExpense = ContextKey("recurrentExpenseID")
 	KeyMacroEntry       = ContextKey("macroEntryID")

--- a/internal/handlers/handle_csp_report.go
+++ b/internal/handlers/handle_csp_report.go
@@ -1,0 +1,20 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+)
+
+// PostCSPReport logs browser-sent CSP violation reports. It gives a
+// server-side signal when the nonce-only policy blocks an inline script or
+// style, so template regressions surface in logs instead of failing silently
+// in the browser. The endpoint is unauthenticated and CSRF-exempt because
+// browsers post reports automatically without cookies or tokens.
+func (h *Handler) PostCSPReport(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err == nil && len(body) > 0 {
+		h.app.Logger.Errorf("csp violation report: %s", body)
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/serve/errs.go
+++ b/internal/serve/errs.go
@@ -2,4 +2,7 @@ package serve
 
 import "errors"
 
-var ErrLayoutNotFound = errors.New("layout template not found")
+var (
+	ErrLayoutNotFound  = errors.New("layout template not found")
+	ErrNonceGeneration = errors.New("failed to generate csp nonce")
+)

--- a/internal/serve/middleware.go
+++ b/internal/serve/middleware.go
@@ -2,8 +2,11 @@ package serve
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -53,7 +56,7 @@ func (s *Server) AuthMiddleware(next http.Handler) http.Handler {
 			return
 		}
 
-		if strings.HasPrefix(path, "/static/") {
+		if strings.HasPrefix(path, "/static/") || path == cspReportPath {
 			next.ServeHTTP(w, r)
 
 			return
@@ -71,6 +74,8 @@ func (s *Server) AuthMiddleware(next http.Handler) http.Handler {
 
 func (s *Server) csrf(next http.Handler) http.Handler {
 	csrfHandler := nosurf.New(next)
+	// Browsers post CSP reports automatically with no CSRF token.
+	csrfHandler.ExemptPath(cspReportPath)
 	csrfHandler.SetBaseCookie(http.Cookie{
 		HttpOnly: true,
 		Path:     "/",
@@ -102,8 +107,11 @@ func (s *Server) setTmplData(next http.Handler) http.Handler {
 			}
 		}
 
+		nonce, _ := ctx.Value(handlers.KeyCSPNonce).(string)
+
 		templateMap := map[string]any{
 			"csrfToken":      csrf,
+			"cspNonce":       nonce,
 			"error":          "",
 			"isUserSignedIn": isUserSignedIn,
 			"currentUser":    currentUser,
@@ -124,14 +132,66 @@ func (*Server) limitRequestBody(next http.Handler) http.Handler {
 	})
 }
 
-func (*Server) securityHeaders(next http.Handler) http.Handler {
+func generateNonce() (string, error) {
+	buf := make([]byte, 16)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrNonceGeneration, err)
+	}
+
+	return base64.StdEncoding.EncodeToString(buf), nil
+}
+
+// cspReportPath receives browser CSP violation reports so a blocked inline
+// script/style produces a server-side signal instead of failing silently.
+const cspReportPath = "/csp-report"
+
+func buildCSP(nonce string) string {
+	return "default-src 'self'; " +
+		"script-src 'self' 'nonce-" + nonce + "'; " +
+		"style-src 'self' 'nonce-" + nonce + "'; " +
+		"img-src 'self' data:; " +
+		"font-src 'self'; " +
+		"connect-src 'self'; " +
+		"object-src 'none'; " +
+		"base-uri 'self'; " +
+		"form-action 'self'; " +
+		"frame-ancestors 'none'; " +
+		"report-uri " + cspReportPath + "; " +
+		"report-to csp"
+}
+
+func (s *Server) securityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
+
+		if s.app.IsProduction() {
+			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
+
+		// Static assets carry no nonce'd markup — skip the per-request nonce
+		// generation and CSP on the asset hot path.
+		if strings.HasPrefix(r.URL.Path, "/static/") {
+			next.ServeHTTP(w, r)
+
+			return
+		}
+
+		nonce, err := generateNonce()
+		if err != nil {
+			s.app.Logger.Errorf("%v", err)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+
+			return
+		}
+
+		w.Header().Set("Reporting-Endpoints", `csp="`+cspReportPath+`"`)
+		w.Header().Set("Content-Security-Policy", buildCSP(nonce))
+		w.Header().Set("X-Frame-Options", "DENY")
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 
-		next.ServeHTTP(w, r)
+		ctx := context.WithValue(r.Context(), handlers.KeyCSPNonce, nonce)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 

--- a/internal/serve/routes.go
+++ b/internal/serve/routes.go
@@ -13,6 +13,8 @@ func (s *Server) setUpRoutes() {
 
 		root.Get("/", s.handlers.GetRoot)
 
+		root.Post(cspReportPath, s.handlers.PostCSPReport)
+
 		root.Get("/login", s.handlers.GetLogin)
 		root.Post("/login", s.handlers.PostLogin)
 		root.Get("/register", s.handlers.GetRegister)

--- a/web/static/css/layout.css
+++ b/web/static/css/layout.css
@@ -735,8 +735,12 @@ button:focus-visible {
   max-width: var(--size-form);
 }
 
-p[style*="color: red"] {
-  color: var(--color-danger) !important;
+.form-error-text {
+  color: var(--color-danger);
+}
+
+.btn-align-end {
+  align-self: flex-end;
 }
 
 @media (width <= 48rem) {

--- a/web/static/js/controllers/submitOnChangeController.ts
+++ b/web/static/js/controllers/submitOnChangeController.ts
@@ -1,0 +1,10 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Submits the containing form when the element's value changes, replacing
+// inline `onchange="this.form.submit()"` handlers that CSP now blocks.
+export default class extends Controller {
+  submit(event: Event) {
+    const el = event.target as HTMLInputElement | HTMLSelectElement;
+    el.form?.requestSubmit();
+  }
+}

--- a/web/static/js/index.ts
+++ b/web/static/js/index.ts
@@ -24,6 +24,7 @@ import MoodChartController from "./controllers/moodChartController";
 import ThemeController from "./controllers/themeController";
 import QuickExpenseController from "./controllers/quickExpenseController";
 import DateHelpController from "./controllers/dateHelpController";
+import SubmitOnChangeController from "./controllers/submitOnChangeController";
 import { initIcons } from "./icons";
 
 window.Stimulus = Application.start();
@@ -43,6 +44,7 @@ window.Stimulus.register("mood-chart", MoodChartController);
 window.Stimulus.register("theme", ThemeController);
 window.Stimulus.register("quick-expense", QuickExpenseController);
 window.Stimulus.register("date-help", DateHelpController);
+window.Stimulus.register("submit-on-change", SubmitOnChangeController);
 
 // turbo:load covers full-page visits; turbo:render also fires when Turbo
 // re-renders a form response (including non-2xx error re-renders), which

--- a/web/views/common/_form_error.html
+++ b/web/views/common/_form_error.html
@@ -1,5 +1,5 @@
 {{ define "form_error" }}
   {{ if ne .error "" }}
-    <p style="color: red;">{{ .error }}</p>
+    <p class="form-error-text">{{ .error }}</p>
   {{ end }}
 {{ end }}

--- a/web/views/error/index.html
+++ b/web/views/error/index.html
@@ -1,5 +1,5 @@
 {{ template "layout" . }}
 {{ define "main" }}
   <h1>ERROR</h1>
-  <p style="color: red;">{{ .error }}</p>
+  <p class="form-error-text">{{ .error }}</p>
 {{ end }}

--- a/web/views/layout.html
+++ b/web/views/layout.html
@@ -5,7 +5,8 @@
       <meta charset="UTF-8" />
       <meta http-equiv="X-UA-Compatible" content="IE=edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <script>
+      <meta name="csp-nonce" content="{{ .cspNonce }}" />
+      <script nonce="{{ .cspNonce }}">
         (function () {
           try {
             var pref = localStorage.getItem("theme") || "auto";

--- a/web/views/macros/index.html
+++ b/web/views/macros/index.html
@@ -51,13 +51,18 @@
           type="date"
           name="date"
           value="{{ .selectedDate }}"
-          onchange="this.form.submit()"
+          data-controller="submit-on-change"
+          data-action="change->submit-on-change#submit"
         />
       </label>
       <label>
         <span class="sr-only">Meal</span>
         <i data-lucide="utensils" class="filter-icon" aria-hidden="true"></i>
-        <select name="meal_type" onchange="this.form.submit()">
+        <select
+          name="meal_type"
+          data-controller="submit-on-change"
+          data-action="change->submit-on-change#submit"
+        >
           <option value="">All meals</option>
           <option
             value="breakfast"

--- a/web/views/macros/stats.html
+++ b/web/views/macros/stats.html
@@ -30,7 +30,7 @@
         </a>
       </nav>
     </header>
-    <div class="filters">
+    <form method="get" action="/macros/stats" class="filters">
       <label>
         <span class="sr-only">Period</span>
         <i
@@ -38,7 +38,11 @@
           class="filter-icon"
           aria-hidden="true"
         ></i>
-        <select onchange="window.location='/macros/stats?period='+this.value">
+        <select
+          name="period"
+          data-controller="submit-on-change"
+          data-action="change->submit-on-change#submit"
+        >
           <option value="week" {{ if eq .period "week" }}selected{{ end }}>
             Last 7 days
           </option>
@@ -53,7 +57,7 @@
           </option>
         </select>
       </label>
-    </div>
+    </form>
     <div
       class="chart-container"
       data-controller="macro-trend"

--- a/web/views/mood_entries/stats.html
+++ b/web/views/mood_entries/stats.html
@@ -27,9 +27,7 @@
         <i data-lucide="calendar" class="filter-icon" aria-hidden="true"></i>
         <input type="date" name="to_date" value="{{ .toDate }}" />
       </label>
-      <button type="submit" class="btn-primary" style="align-self: flex-end">
-        Apply
-      </button>
+      <button type="submit" class="btn-primary btn-align-end">Apply</button>
     </form>
     <div
       class="chart-container"


### PR DESCRIPTION
## What

Hardens the app against XSS, clickjacking, and injection by adding a per-request nonce-based **Content-Security-Policy** plus supporting security headers.

## Changes

**Security headers** (`securityHeaders` middleware)
- CSP with a fresh per-request nonce on `script-src`/`style-src` (no `unsafe-inline`), plus `object-src 'none'`, `base-uri 'self'`, `form-action 'self'`, `frame-ancestors 'none'`.
- `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy`, and `Strict-Transport-Security` (production only).
- Nonce flows: request context -> `setTmplData` (`cspNonce`) -> layout `<meta name="csp-nonce">` + inline `<script>`. Turbo reads the meta and self-nonces its injected progress-bar `<style>`.

**Performance**
- Skip nonce/CSP generation on the `/static/*` asset hot path (still sets `nosniff`/HSTS).

**Observability**
- New `POST /csp-report` endpoint (CSRF- and auth-exempt) logs browser CSP violation reports via `Reporting-Endpoints` + `report-uri`/`report-to`, so blocked inline markup surfaces server-side instead of failing silently.

**Template migrations** (required by nonce-only policy)
- Inline `onchange` handlers -> `submit-on-change` Stimulus controller; stats period `<select>` wrapped in a real GET form.
- Inline `style=` attributes -> CSS classes (`form-error-text`, `btn-align-end`); dropped the old `p[style*="color: red"]` hack.

## Testing
- `make lint-fix`, `make test` — all pass.
- Runtime-verified: CSP header + matching nonce on dynamic pages, no CSP on static assets, `/csp-report` returns 204 and logs the report.

## Notes / follow-ups (not in this PR)
- Auth rate-limiting and a bcrypt cost bump remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)